### PR TITLE
enh:cart icon responsivity

### DIFF
--- a/packages/components/NavBar.tsx
+++ b/packages/components/NavBar.tsx
@@ -23,7 +23,7 @@ function NavBar() {
       <Box
         bgColor="first.250"
         w="100%"
-        h={{ base: '15em', md: '7em' }}
+        h={{ base: '16em', md: '7em' }}
         display="flex"
         justifyContent="center"
         alignItems="center"
@@ -64,7 +64,12 @@ function NavBar() {
             justifyContent="center"
             alignItems="center"
           >
-            <Box display="flex" flexDirection="column" alignItems="center">
+            <Box
+              display="flex"
+              flexDirection="column"
+              alignItems="center"
+              marginTop={{ base: '-20px', md: '10px' }}
+            >
               <Link href="/cart" position="relative">
                 <Image
                   src={images.cart}


### PR DESCRIPTION
# Descrição

cart btn is overflowing at smaller screens so here we push him up a bit and grow the navbar height as well






## Changes

## before:
![image](https://user-images.githubusercontent.com/86134825/163876977-f99938a4-fc07-42f6-b2c5-087a541c7ec8.png)
## after: 
![image](https://user-images.githubusercontent.com/86134825/163877089-64c82c7a-b789-4b7d-b637-77b8ba1c4d6f.png)

