### PR TITLE
enh: Add folder and files validation

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -6,6 +6,7 @@ extends:
 plugins:
   - 'unused-imports'
   - '@typescript-eslint'
+  - 'repo-structure'
 
 rules:
   # typescript-eslint
@@ -69,3 +70,7 @@ rules:
         - sibling
         - index
         - type
+  repo-structure/file-structure: error
+
+settings:
+  repo-structure/config-path: .repo-structurerc.yml

--- a/.github/workflows/quality-gateway-pull-request.yml
+++ b/.github/workflows/quality-gateway-pull-request.yml
@@ -12,6 +12,7 @@ jobs:
           node-version: '16.x'
       - run: yarn install
       - run: yarn lint
+      - run: yarn lint-folders
       - run: yarn build:static
         env:
           FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}

--- a/.repo-structurerc.yml
+++ b/.repo-structurerc.yml
@@ -1,0 +1,88 @@
+root:
+  children:
+    - name: .github
+      children:
+        - name: workflows
+          children:
+            - case: dash-case
+
+    - name: docs
+      children:
+        - id: image-folder
+
+    - name: packages
+      children:
+        - name: assets
+
+        - name: components
+          children:
+            - case: dash-case
+              children:
+                - name: index
+                  extension: '.tsx'
+                - id: react-component-file
+
+            - name: Styles
+
+            - id: react-component-file
+
+            - name: index
+              extension: '.tsx'
+
+        - name: config
+          children:
+            - case: dash-case
+              extension: '.ts'
+
+        - name: entities
+          children:
+            - case: PascalCase
+              name: '/^I.*$/'
+              extension: '.ts'
+
+        - name: enums
+          children:
+            - case: PascalCase
+              name: '/^.*Type$/'
+              extension: '.ts'
+
+        - name: features
+          children:
+            - case: dash-case
+              name: '/^.*context$/'
+              extension: '.tsx'
+
+        - name: locale
+
+        - name: utils
+          children:
+            - case: camelCase
+              extension:
+                - '.tsx'
+                - '.ts'
+
+    - name: pages
+      children:
+        - extension: .tsx
+        - name: api
+
+    - name: public
+      children:
+        - id: image-folder
+
+rules:
+  react-component-file:
+    extension: '.tsx'
+    case: PascalCase
+
+  image-file:
+    extension:
+      - .png
+      - .svg
+    case: dash-case
+
+  image-folder:
+    case: dash-case
+    children:
+      - id: image-folder
+      - id: image-file

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build:static": "next build && next export",
     "start": "next start",
     "lint": "next lint",
+    "lint-folders": "yarn eslint --parser ./node_modules/eslint-plugin-repo-structure/parser.js --rule repo-structure/file-structure:error --ext .js,.ts,.tsx,.css,.svg,.yml,.png .",
     "fmt": "prettier --write . && next lint --fix --dir packages",
     "prepare": "husky install"
   },
@@ -18,6 +19,7 @@
     "@emotion/react": "^11",
     "@emotion/styled": "^11",
     "chakra-ui-steps": "^1.5.0",
+    "eslint-plugin-repo-structure": "^0.1.0",
     "firebase": "^9.1.3",
     "formik": "^2.2.9",
     "framer-motion": "^4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1687,6 +1687,11 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
 aria-hidden@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.1.3.tgz#bb48de18dc84787a3c6eee113709c473c64ec254"
@@ -2570,6 +2575,13 @@ eslint-plugin-react@^7.23.1:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.6"
 
+eslint-plugin-repo-structure@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-repo-structure/-/eslint-plugin-repo-structure-0.1.0.tgz#f4ca5178f93877a99980d9fd196fd0f6fac600ac"
+  integrity sha512-Z6iXoKqCj2n0LzGR3AQnzEOaIPOjTf3Go5aL+imKu6YpLHkwlH2mpPJjrEZLp7nNrEOXsZ5odtVvxGTXn/iZ2Q==
+  dependencies:
+    js-yaml "^4.1.0"
+
 eslint-plugin-unused-imports@^1.1.4:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-1.1.5.tgz#a2b992ef0faf6c6c75c3815cc47bde76739513c2"
@@ -3444,6 +3456,13 @@ js-yaml@^3.13.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+js-yaml@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
 
 json-parse-even-better-errors@^2.3.0:
   version "2.3.1"


### PR DESCRIPTION
# Descrição
 Essa PR integra a ferramenta [eslint-plugin-repo-structure](https://github.com/eduhdm/eslint-plugin-repo-structure), que valida se a estrutura de arquivos e pastas é válida dado o schema definido em `.repo-structurerc.yml`. Esse comando foi adicionado ao github actions para garantir que novos arquivos sigam o padrão definido.


## Changes

- Instala plugin 
- Cria arquivo de configuração com estrutura de pastas e arquivos
- Cria comando yarn lint-folders que valida se arquivos de diversas extensões são escritos corretamente
- Inclui comando no Github actions
